### PR TITLE
💥 fix!: Remove `ruby/setup-ruby` from `action.yml` and allow users to configure it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f  # v1.227.0
+        with:
+          ruby-version: ruby
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}
@@ -24,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f  # v1.227.0
+        with:
+          ruby-version: ruby
       - uses: ./
         with:
           github_token: ${{ secrets.github_token }}
@@ -37,6 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f  # v1.227.0
+        with:
+          ruby-version: ruby
       - uses: ./
         continue-on-error: true
         with:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f  # v1.227.0
       - uses: blooper05/action-rails_best_practices@14a7d36a50f927d790d08ca78009468711e62055  # v1.0.3
         with:
           github_token: ${{ secrets.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -45,9 +45,6 @@ runs:
     - uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893  # v1.3.2
       with:
         reviewdog_version: v0.14.1
-    - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f  # v1.227.0
-      with:
-        ruby-version: 3.1
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:


### PR DESCRIPTION
BREAKING CHANGE: Users must now explicitly set up Ruby in their workflows.

Previously, `ruby/setup-ruby` was included in `action.yml`, which automatically set up Ruby for users.
With this change, users need to manually add `ruby/setup-ruby` in their GitHub Actions workflow before using this action.

Example update required in `.github/workflows/your-workflow.yml`:

```yaml
jobs:
  rails_best_practices:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: ruby/setup-ruby@v1
      - uses: blooper05/action-rails_best_practices@v2
```

fix #6
